### PR TITLE
Updated missing library in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4>=4.4.1
 pysnmp>=4.3.2
 gnureadline>=6.3.3
 python-nmap
+scapy


### PR DESCRIPTION
Library "scapy" was missing.
It is used in 'icssploit/modules/creds/s7_bruteforce.py'